### PR TITLE
Expose the `open` Query Function

### DIFF
--- a/src/NSelect.purs
+++ b/src/NSelect.purs
@@ -14,6 +14,7 @@ module NSelect
   , setMenuProps
   , setItemProps
   , component
+  , open
   , close
   , focus
   , highlight


### PR DESCRIPTION
Add the `open` function to the export list of the NSelect module.