### PR TITLE
Handle keydown only when isOpen, call scrollIntoViewIfNeeded on open

### DIFF
--- a/examples/src/Example/Autocomplete.purs
+++ b/examples/src/Example/Autocomplete.purs
@@ -63,7 +63,8 @@ renderSelect state st =
   ) $ join
   [ pure $ HH.input
     ( Select.setInputProps
-      [ HP.value state.value
+      [ style "width: 20rem"
+      , HP.value state.value
       ]
     )
   , guard st.isOpen $> HH.div


### PR DESCRIPTION
Fix two issues raised by @prikhi in https://github.com/nonbili/purescript-halogen-nselect/pull/1#issuecomment-484423985

1. ArrowUp/ArrowDown should not change `highlightedIndex` when `isOpen == false`
2. should make highlighted item visible when dropdown is opened