### PR TITLE
 Expose Query constructors, add GetInputElement query

### DIFF
--- a/examples/src/Example/Autocomplete.purs
+++ b/examples/src/Example/Autocomplete.purs
@@ -112,7 +112,7 @@ handleAction (HandleDropdown msg) = case msg of
     state <- H.get
     for_ (Array.index state.filteredItems index) \item ->
       H.modify_ $ _ { value = item }
-    void $ H.query _dropdown unit Select.close
+    void $ H.query _dropdown unit $ H.tell Select.Close
   Select.InputValueChanged value -> do
     H.modify_ $ \state -> state
       { value = value

--- a/examples/src/Example/TwoInputs.purs
+++ b/examples/src/Example/TwoInputs.purs
@@ -129,7 +129,7 @@ handleAction (OnKeyDownInput slot kbEvent) = do
   case KE.key kbEvent of
     "Tab" -> do
       H.liftEffect $ Event.preventDefault event
-      void $ H.query _dropdown slot Select.select
+      void $ H.query _dropdown slot $ H.tell Select.Select
     _ -> pure unit
 handleAction (HandleDropdown slot msg) = case msg of
   Select.Selected index -> do
@@ -138,9 +138,9 @@ handleAction (HandleDropdown slot msg) = case msg of
       case slot of
         DropdownFrom -> H.modify_ $ _ { from = item }
         DropdownTo -> H.modify_ $ _ { to = item }
-    void $ H.query _dropdown slot Select.close
+    void $ H.query _dropdown slot $ H.tell Select.Close
     when (slot == DropdownFrom) $ do
-      void $ H.query _dropdown DropdownTo Select.focus
+      void $ H.query _dropdown DropdownTo $ H.tell Select.Focus
   Select.InputValueChanged value -> do
     case slot of
       DropdownFrom -> H.modify_ $ _ { from = value }

--- a/src/NSelect.purs
+++ b/src/NSelect.purs
@@ -34,6 +34,7 @@ import Web.DOM.Element as Element
 import Web.DOM.ParentNode (QuerySelector(..), querySelector)
 import Web.Event.Event as Event
 import Web.HTML as Web
+import Web.HTML.HTMLElement (HTMLElement)
 import Web.HTML.HTMLElement as HTMLElement
 import Web.HTML.Window as Window
 import Web.UIEvent.FocusEvent (FocusEvent)
@@ -59,6 +60,7 @@ data Query a
   | Highlight Int a
   | Select a
   | GetState (State -> a)
+  | GetInputElement (HTMLElement -> a)
 
 data Action pa cs m
   = Init
@@ -380,5 +382,12 @@ handleQuery = case _ of
     state <- H.get
     pure $ Just $ q $ innerStateToState state
 
+  GetInputElement q -> do
+    H.getHTMLElementRef inputRef >>= case _ of
+      Nothing -> pure Nothing
+      Just el -> pure $ Just $ q el
+
+-- A helper function to redirect parent action through the `Emit` message, so
+-- that parent component can handle it.
 raise :: forall pa cs m. pa -> Action pa cs m
 raise = Raise

--- a/src/NSelect.purs
+++ b/src/NSelect.purs
@@ -1,7 +1,7 @@
 module NSelect
   ( Props
   , Message(..)
-  , Query
+  , Query(..)
   , Action
   , State
   , HTML
@@ -14,13 +14,7 @@ module NSelect
   , setMenuProps
   , setItemProps
   , component
-  , open
-  , close
-  , focus
-  , highlight
   , raise
-  , select
-  , getState
   ) where
 
 import Prelude
@@ -386,24 +380,5 @@ handleQuery = case _ of
     state <- H.get
     pure $ Just $ q $ innerStateToState state
 
--- | Following are helpers so that you can query from the parent component.
-open :: Query Unit
-open = Open unit
-
-close :: Query Unit
-close = Close unit
-
-focus :: Query Unit
-focus = Focus unit
-
-highlight :: Int -> Query Unit
-highlight index = Highlight index unit
-
 raise :: forall pa cs m. pa -> Action pa cs m
 raise = Raise
-
-select :: Query Unit
-select = Select unit
-
-getState :: forall a. (State -> a) -> Query a
-getState = GetState


### PR DESCRIPTION
This is a breaking change. I think it's unreasonable to hide Query constructors.