### PR TITLE
Add preventDefault to item clicks

### DIFF
--- a/src/NSelect.purs
+++ b/src/NSelect.purs
@@ -72,7 +72,7 @@ data Action pa cs m
   | OnFocusInput
   | OnKeyDownInput KE.KeyboardEvent
   | OnKeyDownInput' (KeyDownHandler pa) KE.KeyboardEvent
-  | OnClickItem Int
+  | OnClickItem Int ME.MouseEvent
   | OnMouseEnterItem Int
   | OnValueInput String
   | Raise pa
@@ -206,7 +206,7 @@ setItemProps
   -> Array (HH.IProp (ItemProps r) (Action pa cs m))
 setItemProps index props = props <>
   [ HH.attr (HH.AttrName "data-nselect-item") (show index)
-  , HE.onClick $ Just <<< const (OnClickItem index)
+  , HE.onClick $ Just <<< OnClickItem index
   , HE.onMouseEnter $ Just <<< const (OnMouseEnterItem index)
   ]
 
@@ -334,7 +334,8 @@ handleAction = case _ of
     handleAction (OnKeyDownInput kbEvent)
     H.raise $ Emit $ parentOnKeyDown kbEvent
 
-  OnClickItem index -> do
+  OnClickItem index ev -> do
+    H.liftEffect $ Event.preventDefault $ ME.toEvent $ ev
     H.raise $ Selected index
 
   OnMouseEnterItem index -> do


### PR DESCRIPTION
A small change to preventDefault item clicks to keep a containing <form> from submitting.

Thanks very much for your efforts with this library!