### PR TITLE
Revert "Add preventDefault to item clicks"

### DIFF
--- a/src/NSelect.purs
+++ b/src/NSelect.purs
@@ -72,7 +72,7 @@ data Action pa cs m
   | OnFocusInput
   | OnKeyDownInput KE.KeyboardEvent
   | OnKeyDownInput' (KeyDownHandler pa) KE.KeyboardEvent
-  | OnClickItem Int ME.MouseEvent
+  | OnClickItem Int
   | OnMouseEnterItem Int
   | OnValueInput String
   | Raise pa
@@ -206,7 +206,7 @@ setItemProps
   -> Array (HH.IProp (ItemProps r) (Action pa cs m))
 setItemProps index props = props <>
   [ HH.attr (HH.AttrName "data-nselect-item") (show index)
-  , HE.onClick $ Just <<< OnClickItem index
+  , HE.onClick $ Just <<< const (OnClickItem index)
   , HE.onMouseEnter $ Just <<< const (OnMouseEnterItem index)
   ]
 
@@ -334,8 +334,7 @@ handleAction = case _ of
     handleAction (OnKeyDownInput kbEvent)
     H.raise $ Emit $ parentOnKeyDown kbEvent
 
-  OnClickItem index ev -> do
-    H.liftEffect $ Event.preventDefault $ ME.toEvent $ ev
+  OnClickItem index -> do
     H.raise $ Selected index
 
   OnMouseEnterItem index -> do


### PR DESCRIPTION
@pbrant sorry, seems I have to revert #4 as it breaks checkbox or something else. Suppose I have a dropdown that supports multi-select. The `preventDefault` prevents checkbox from being checked on click.  
![image](https://user-images.githubusercontent.com/1082650/62253339-8b4cb200-b430-11e9-8b60-005a4091d61c.png)
```
      -- This is not a problem for fully-controlled compoment. 
      -- But for uncontrolled component, it's unexpected behavior to a user
      HH.label
      ( Select.setItemProps index
        []
      )
      [ HH.input
        [ HP.type_ HP.InputCheckbox ]
      , HH.text item
      ]
```

On the other hand, I find a workaround for your case, you can `preventDefault` on a parent element, like
```
    [ HH.ul
      ( Select.setMenuProps
        [ HH.attr (HH.AttrName "onclick") "event.preventDefault();"
        ]
      ) $ 
      HH.li
      ( Select.setItemProps index
```

Does this make sense to you?